### PR TITLE
Only send changed accounts to listeners

### DIFF
--- a/txpool/txpool_control.proto
+++ b/txpool/txpool_control.proto
@@ -8,6 +8,7 @@ message AccountInfoRequest {
   bytes block_hash = 1;
   bytes account = 2;
 }
+
 message AccountInfoReply {
   bytes balance = 1;
   bytes nonce = 2;
@@ -26,17 +27,10 @@ message AccountInfo {
   bytes nonce = 3;
 }
 
-message AccountDiff {
-  oneof diff {
-    AccountInfo changed = 1;
-    bytes deleted = 2;
-  }
-}
-
 message AppliedBlock {
   bytes hash = 1;
   bytes parent_hash = 2;
-  repeated AccountDiff account_diffs = 3;
+  repeated AccountInfo account_diffs = 3;
 }
 
 message RevertedBlock {
@@ -44,7 +38,7 @@ message RevertedBlock {
   repeated bytes reverted_transactions = 2;
   bytes new_hash = 3;
   bytes new_parent = 4;
-  repeated AccountDiff new_state = 5;
+  repeated AccountInfo account_diffs = 5;
 }
 
 message BlockDiff {

--- a/txpool/txpool_control.proto
+++ b/txpool/txpool_control.proto
@@ -38,7 +38,7 @@ message RevertedBlock {
   repeated bytes reverted_transactions = 2;
   bytes new_hash = 3;
   bytes new_parent = 4;
-  repeated AccountInfo account_diffs = 5;
+  repeated AccountInfo reverted_accounts = 5;
 }
 
 message BlockDiff {

--- a/txpool/txpool_control.proto
+++ b/txpool/txpool_control.proto
@@ -30,7 +30,7 @@ message AccountInfo {
 message AppliedBlock {
   bytes hash = 1;
   bytes parent_hash = 2;
-  repeated AccountInfo account_diffs = 3;
+  repeated AccountInfo changed_accounts = 3;
 }
 
 message RevertedBlock {


### PR DESCRIPTION
After implementing a provider for this interface, I found that the `deleted` type of account diff was not needed since `deleted` is basically equivalent to notifying subscribed txpools that the account's new nonce and balance is 0.