### PR TITLE
Reverted accounts => changed accounts

### DIFF
--- a/txpool/txpool_control.proto
+++ b/txpool/txpool_control.proto
@@ -38,7 +38,7 @@ message RevertedBlock {
   repeated bytes reverted_transactions = 2;
   bytes new_hash = 3;
   bytes new_parent = 4;
-  repeated AccountInfo reverted_accounts = 5;
+  repeated AccountInfo changed_accounts = 5;
 }
 
 message BlockDiff {


### PR DESCRIPTION
copied from [here](https://github.com/ledgerwatch/interfaces/pull/7/commits/a684a2cd766684d79ff9de5476577d56d7057f2e#r582261764): 

> Just noticed that this was changed - maybe I misunderstand the interface, but I've implemented to provider to send subscribers the latest block hash and the latest account values for every addressed that was touched. For applied blocks, this is simple. It's just the accounts in the latest block. For reverted blocks, it's more complicated because every account that sent a tx on the reverted fork and the canonical fork should have an update in the diff so that the txpool can adjust its values accordingly. The use of reverted_accounts makes me think there is a misunderstanding somewhere, because in my view this field would also include accounts from the non-reverted chain.