### PR TITLE
Add interface versioning mechanism

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,7 @@ fn make_protos(protos: &[&str]) {
 }
 
 fn main() {
-    let mut protos = vec!["types/types.proto"];
+    let mut protos = vec!["types/types.proto", "version/version.proto"];
 
     if cfg!(feature = "consensus") {
         protos.push("consensus_engine/consensus.proto");

--- a/remote/kv.proto
+++ b/remote/kv.proto
@@ -1,11 +1,26 @@
 syntax = "proto3";
 
+import "google/protobuf/empty.proto";
+import "version/version.proto";
+
+// This is the Application Interface Version: change these numbers according to semver rules
+// anytime the application-level protocol changes (e.g. string or bytes format)
+option (interface_major_version) = 1;
+option (interface_minor_version) = 0;
+option (interface_patch_version) = 0;
+
 package remote;
 
 option go_package = "./remote;remote";
 
 // Provides methods to access key-value data
-service KV { rpc Tx(stream Cursor) returns (stream Pair); }
+service KV {
+  // GetInterfaceVersion returns the service-side interface version number
+  rpc GetInterfaceVersion(google.protobuf.Empty) returns (InterfaceVersionReply);
+
+  // Tx exposes read-only transactions for the key-value store
+  rpc Tx(stream Cursor) returns (stream Pair);
+}
 
 enum Op {
   FIRST = 0;

--- a/remote/kv.proto
+++ b/remote/kv.proto
@@ -5,9 +5,9 @@ import "version/version.proto";
 
 // This is the Application Interface Version: change these numbers according to semver rules
 // anytime the application-level protocol changes (e.g. string or bytes format)
-option (interface_major_version) = 1;
-option (interface_minor_version) = 0;
-option (interface_patch_version) = 0;
+option (version.interface_major_version) = 1;
+option (version.interface_minor_version) = 0;
+option (version.interface_patch_version) = 0;
 
 package remote;
 
@@ -16,7 +16,7 @@ option go_package = "./remote;remote";
 // Provides methods to access key-value data
 service KV {
   // GetInterfaceVersion returns the service-side interface version number
-  rpc GetInterfaceVersion(google.protobuf.Empty) returns (InterfaceVersionReply);
+  rpc GetInterfaceVersion(google.protobuf.Empty) returns (version.InterfaceVersionReply);
 
   // Tx exposes read-only transactions for the key-value store
   rpc Tx(stream Cursor) returns (stream Pair);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,10 @@ pub mod types {
     U!(H512, ethereum_types::H512, ethereum_types::U512);
 }
 
+pub mod version {
+    tonic::include_proto!("version");
+}
+
 #[cfg(feature = "consensus")]
 pub mod consensus {
     tonic::include_proto!("consensus");

--- a/version/version.proto
+++ b/version/version.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-//package version;
+package version;
 
 import "google/protobuf/descriptor.proto";
 

--- a/version/version.proto
+++ b/version/version.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+//package version;
+
+import "google/protobuf/descriptor.proto";
+
+/* Application-level versioning shall use a 3-part version number (M.m.p) following semver rules */
+/* 1. MAJOR version (M): increment when you make incompatible changes                            */
+/* 2. MINOR version (m): increment when you add functionality in backward compatible manner      */
+/* 3. PATCH version (p): increment when you make backward compatible bug fixes                   */
+
+// Extensions of file-level options for interface version: should *not* be modified
+extend google.protobuf.FileOptions {
+  uint32 interface_major_version = 50001;
+  uint32 interface_minor_version = 50002;
+  uint32 interface_patch_version = 50003;
+}
+
+// Reply message containing the current interface version on the service side
+message InterfaceVersionReply {
+  uint32 current_major_number = 1;
+  uint32 current_minor_number = 2;
+  uint32 current_patch_number = 3;
+}


### PR DESCRIPTION
The basic idea behind this interface versioning mechanism is:

- both gRPC client and server include a proto file containing the interface version as (M=major, m=minor, p=patch) [semver](https://semver.org/) triple 
- the gRPC client *asks the gRPC server for the (M.m.p)s* and perform the *compatibility check against its (M.m.p)c*

A simple compatibility check can be done with the following rules:

- if Mc == Ms and mc <= ms the interfaces are fully compatible
- otherwise some or all interface functionalities could not work properly

This interface versioning mechanism requires any gRPC interface to declare in its proto file:

- the (M.m.p) numbers as constants
- the `GetInterfaceVersion` method in the service

The interface version numbers are declared using the protobuf `FileOptions`, which is a weird trick to simulate constants at proto file level.

I've tried to factor as many content as possible in the common `version` module in order to reduce the changes required in each proto and I've just added the interface version to the KV proto.

In Go the `GetInterfaceVersion` method implementation looks like:

```
func (KvServer) GetInterfaceVersion(context.Context, *emptypb.Empty) (*version.InterfaceVersionReply, error) {
	reply := new(version.InterfaceVersionReply)
	options := remote.File_remote_kv_proto.Options()
	reply.CurrentMajorNumber = proto.GetExtension(options, version.E_InterfaceMajorVersion).(uint32);
	reply.CurrentMinorNumber = proto.GetExtension(options, version.E_InterfaceMinorVersion).(uint32);
	reply.CurrentPatchNumber = proto.GetExtension(options, version.E_InterfacePatchVersion).(uint32);
	return reply, nil
}
```