### PR TITLE
Testing interface

### DIFF
--- a/testing/testing.proto
+++ b/testing/testing.proto
@@ -11,7 +11,7 @@ mesage TestReport {
     bool end = 1;
     // Indication whether the report is about success of part of the test, or failure
     bool success = 2;
-    string message = 3;
+    string log = 3;
 }
 
 service TestDriver {

--- a/testing/testing.proto
+++ b/testing/testing.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package testing;
+
+option go_package = "./testing;testing";
+
+mesage TestReport {
+    // End of test signal
+    bool end = 1;
+    // Indication whether the report is about success of part of the test, or failure
+    bool success = 2;
+    string message = 3;
+}
+
+service TestDriver {
+  // Returns number of available integration test caes in the test driver
+  rpc TestCaseCount(google.protobuf.Empty) returns (uint64);
+  // Ask the test driver to start the test case with given number. As test case progresses, the driver sends reports via the stream
+  // Test drivier also notifies about the end of test case via the stream
+  rpc StartTestCase(uint64) returns (stream TestReport);
+}

--- a/testing/testing.proto
+++ b/testing/testing.proto
@@ -6,7 +6,7 @@ package testing;
 
 option go_package = "./testing;testing";
 
-mesage TestReport {
+message TestReport {
     // End of test signal
     bool end = 1;
     // Indication whether the report is about success of part of the test, or failure

--- a/testing/testing.proto
+++ b/testing/testing.proto
@@ -6,6 +6,10 @@ package testing;
 
 option go_package = "./testing;testing";
 
+message TestCaseNumber {
+    uint64 count = 1;
+}
+
 message TestReport {
     // End of test signal
     bool end = 1;
@@ -16,8 +20,8 @@ message TestReport {
 
 service TestDriver {
   // Returns number of available integration test caes in the test driver
-  rpc TestCaseCount(google.protobuf.Empty) returns (uint64);
+  rpc TestCaseCount(google.protobuf.Empty) returns (TestCaseNumber);
   // Ask the test driver to start the test case with given number. As test case progresses, the driver sends reports via the stream
   // Test drivier also notifies about the end of test case via the stream
-  rpc StartTestCase(uint64) returns (stream TestReport);
+  rpc StartTestCase(TestCaseNumber) returns (stream TestReport);
 }


### PR DESCRIPTION
This is an interface of running integration test driver based on gRPC interface for p2p sentry (perhaps later extended to other things). The idea is that turbo-geth (and later silkworm and akula) would be run in an integration test mode, specifying gRPC end points for test driver and for p2psentry. Then, turbo-geth requests the beginning of selected test case, and is fed data via p2psentry interface, and queried about the imported blocks. At the end of a test case, turbo-geth received a special message, so it can clean up and move on to the next test.