### PR TITLE
Implements net_peerCount

### DIFF
--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -11,6 +11,8 @@ service ETHBACKEND {
   rpc Etherbase(EtherbaseRequest) returns (EtherbaseReply);
 
   rpc NetVersion(NetVersionRequest) returns (NetVersionReply);
+  
+  rpc NetPeerCount(NetPeerCountRequest) returns (NetPeerCountReply);
 
   // Version returns the service version number
   rpc Version(google.protobuf.Empty) returns (types.VersionReply);
@@ -37,6 +39,10 @@ message EtherbaseReply { types.H160 address = 1; }
 message NetVersionRequest {}
 
 message NetVersionReply { uint64 id = 1; }
+
+message NetPeerCountRequest {}
+
+message NetPeerCountReply { uint64 id = 1; }
 
 message ProtocolVersionRequest {}
 


### PR DESCRIPTION
Implements NetPeerCount message necessary for `net_peerCount` RPC call (https://github.com/ledgerwatch/erigon/pull/2172)