### PR TITLE
txpool: add Status method

### DIFF
--- a/txpool/txpool.proto
+++ b/txpool/txpool.proto
@@ -44,6 +44,12 @@ message AllReply {
   repeated Tx txs = 1;
 }
 
+message StatusRequest {}
+message StatusReply {
+  uint32 pendingCount = 1;
+  uint32 queuedCount = 2;
+}
+
 service Txpool {
   // Version returns the service version number
   rpc Version(google.protobuf.Empty) returns (types.VersionReply);
@@ -58,4 +64,6 @@ service Txpool {
   rpc All(AllRequest) returns (AllReply);
   // subscribe to new transactions add event
   rpc OnAdd(OnAddRequest) returns (stream OnAddReply);
+  // returns high level status
+  rpc Status(StatusRequest) returns (StatusReply);
 }


### PR DESCRIPTION
Adds the `Txpool.Status()` method, which returns the number of pending and queued transactions.

This is required to efficiently implement the `txpool_status` RPC in Erigon.
Otherwise, Erigon would need to fetch the entire Mempool using `Txpool.All()` and count it on the `rpcdaemon` server.