### PR TITLE
Added "The Merge" Interop specification.

### DIFF
--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -26,7 +26,9 @@ service ETHBACKEND {
   // Execute the payload.
   rpc EngineExecutePayload(common.ExecutionPayload) returns (EngineExecutePayloadReply);
 
+  // Update fork choice
   rpc EngineForkChoiceUpdated(EngineForkChoiceUpdatedRequest) returns (EngineForkChoiceUpdatedReply);
+  
   // Version returns the service version number
   rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 import "types/types.proto";
+import "web3/common.proto";
+
 
 package remote;
 
@@ -13,7 +15,18 @@ service ETHBACKEND {
   rpc NetVersion(NetVersionRequest) returns (NetVersionReply);
   
   rpc NetPeerCount(NetPeerCountRequest) returns (NetPeerCountReply);
+  // "The Merge" RPC Requests to be netively implemented in the Erigon Node Backend
 
+  // Prepare Execution Payload
+  rpc EnginePreparePayload(EnginePreparePayloadRequest) returns (EnginePreparePayloadReply);
+
+  // Fetch Execution Payload using its id.
+  rpc EngineGetPayload(EngineGetPayloadRequest) returns (common.ExecutionPayload);
+
+  // Execute the payload.
+  rpc EngineExecutePayload(common.ExecutionPayload) returns (EngineExecutePayloadReply);
+
+  rpc EngineForkChoiceUpdated(EngineForkChoiceUpdatedRequest) returns (EngineForkChoiceUpdatedReply);
   // Version returns the service version number
   rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 
@@ -43,6 +56,26 @@ message NetVersionReply { uint64 id = 1; }
 message NetPeerCountRequest {}
 
 message NetPeerCountReply { uint64 count = 1; }
+
+message EnginePreparePayloadRequest {
+  types.H256 parentHash = 1;
+  uint64 timestamp = 2;
+  types.H256 random = 3;
+  types.H160 feeRecipient = 4; 
+}
+
+message EnginePreparePayloadReply { uint64 payloadId = 1; }
+
+message EngineGetPayloadRequest { uint64 payloadId = 1; }
+
+message EngineExecutePayloadReply { string status = 1; }
+
+message EngineForkChoiceUpdatedRequest {
+  types.H256 headBlockHash = 1;
+  types.H256 finalizedBlockHash = 2;
+}
+
+message EngineForkChoiceUpdatedReply {}
 
 message ProtocolVersionRequest {}
 

--- a/types/types.proto
+++ b/types/types.proto
@@ -38,6 +38,15 @@ message H512 {
   H256 lo = 2;
 }
 
+message H1024 {
+  H512 hi = 1;
+  H512 lo = 2;
+}
+
+message H2048 {
+  H1024 hi = 1;
+  H1024 lo = 2;
+}
 // Reply message containing the current service version on the service side
 message VersionReply {
   uint32 major = 1;

--- a/web3/common.proto
+++ b/web3/common.proto
@@ -57,3 +57,19 @@ message FullBlock {
   BlockBase base = 1;
   repeated Transaction transactions = 2;
 }
+
+message ExecutionPayload {
+  types.H256 parentHash = 1;
+  types.H160 coinbase = 2;
+  types.H256 stateRoot = 3;
+  types.H2048 logsBloom = 4;
+  types.H256 random = 5;
+  uint64 blockNumber = 6;
+  uint64 gasLimit = 7;
+  uint64 gasUsed = 8;
+  uint64 timestamp = 9;
+  types.H256 extraData = 10;
+  types.H256 baseFeePerGas = 11;
+  types.H256 blockHash = 12;
+  repeated Transaction transactions = 13;
+}


### PR DESCRIPTION
This PR adds the interfaces for https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.2/src/engine/interop/specification.md . these new rpc calls will probably subject to changes but are not likely to change after the end of october. in the Eth R&D i have been told that `engine_ConsensusValidated`will be removed from spec so i did not add it here. This PR is not finalized but i still would like a general review. In addition to this i am unsure how to check wheter the protos are valid or not since cargo always compile. I am also unsure if `ethbacked.proto` is the right place to put these new rpc calls.