### PR TITLE
feat(txpool): search RPC

### DIFF
--- a/txpool/txpool.proto
+++ b/txpool/txpool.proto
@@ -43,8 +43,14 @@ message OnAddReply { repeated bytes rplTxs = 1; }
 message AllRequest {}
 message AllReply { repeated Tx txs = 1; }
 
-message PendingRequest { Tx.Type type = 1; }
-message PendingReply { repeated Tx txs = 1; }
+message SearchRequest {
+  message Filter {
+    optional bytes from = 1;
+  }
+  Tx.Type type = 1;
+  optional Filter filter = 2;
+}
+message SearchReply { repeated Tx txs = 1; }
 
 message StatusRequest {}
 message StatusReply {
@@ -66,7 +72,7 @@ service Txpool {
   // returns all transactions from tx pool
   rpc All(AllRequest) returns (AllReply);
   // returns pending transactions from tx pool
-  rpc Pending(PendingRequest) returns (PendingReply);
+  rpc Search(SearchRequest) returns (SearchReply);
   // subscribe to new transactions add event
   rpc OnAdd(OnAddRequest) returns (stream OnAddReply);
   // returns high level status

--- a/txpool/txpool.proto
+++ b/txpool/txpool.proto
@@ -48,14 +48,9 @@ message SearchRequest {
     optional bytes from = 1;
   }
   Tx.Type type = 1;
-  Filter filter = 2;
-  optional int32 page_size = 3;
-  optional string page_token = 4;
+  optional Filter filter = 2;
 }
-message SearchReply {
-  repeated Tx txs = 1;
-  optional string next_page_token = 2;
-}
+message SearchReply { repeated Tx txs = 1; }
 
 message StatusRequest {}
 message StatusReply {

--- a/txpool/txpool.proto
+++ b/txpool/txpool.proto
@@ -38,14 +38,12 @@ message TransactionsRequest { repeated types.H256 hashes = 1; }
 message TransactionsReply { repeated bytes rlpTxs = 1; }
 
 message OnAddRequest {}
-message OnAddReply {
-  repeated bytes rplTxs = 1;
-}
+message OnAddReply { repeated bytes rplTxs = 1; }
 
 message AllRequest {}
 message AllReply { repeated Tx txs = 1; }
 
-message PendingRequest {}
+message PendingRequest { Tx.Type type = 1; }
 message PendingReply { repeated Tx txs = 1; }
 
 message StatusRequest {}

--- a/txpool/txpool.proto
+++ b/txpool/txpool.proto
@@ -9,6 +9,18 @@ option go_package = "./txpool;txpool";
 
 message TxHashes { repeated types.H256 hashes = 1; }
 
+message Tx {
+  enum Type {
+    PENDING = 0; // All currently processable transactions
+    QUEUED = 1;  // Queued but non-processable transactions
+    BASE_FEE = 2;  // BaseFee not enough baseFee non-processable transactions
+  }
+
+  Type type = 1;
+  bytes sender = 2;
+  bytes rlpTx = 3;
+}
+
 message AddRequest { repeated bytes rlpTxs = 1; }
 
 enum ImportResult {
@@ -31,19 +43,10 @@ message OnAddReply {
 }
 
 message AllRequest {}
-message AllReply {
-  enum Type {
-    PENDING = 0; // All currently processable transactions
-    QUEUED = 1;  // Queued but non-processable transactions
-    BASE_FEE = 2;  // BaseFee not enough baseFee non-processable transactions
-  }
-  message Tx {
-    Type type = 1;
-    bytes sender = 2;
-    bytes rlpTx = 3;
-  }
-  repeated Tx txs = 1;
-}
+message AllReply { repeated Tx txs = 1; }
+
+message PendingRequest {}
+message PendingReply { repeated Tx txs = 1; }
 
 message StatusRequest {}
 message StatusReply {
@@ -64,6 +67,8 @@ service Txpool {
   rpc Transactions(TransactionsRequest) returns (TransactionsReply);
   // returns all transactions from tx pool
   rpc All(AllRequest) returns (AllReply);
+  // returns pending transactions from tx pool
+  rpc Pending(PendingRequest) returns (PendingReply);
   // subscribe to new transactions add event
   rpc OnAdd(OnAddRequest) returns (stream OnAddReply);
   // returns high level status

--- a/txpool/txpool.proto
+++ b/txpool/txpool.proto
@@ -48,9 +48,14 @@ message SearchRequest {
     optional bytes from = 1;
   }
   Tx.Type type = 1;
-  optional Filter filter = 2;
+  Filter filter = 2;
+  optional int32 page_size = 3;
+  optional string page_token = 4;
 }
-message SearchReply { repeated Tx txs = 1; }
+message SearchReply {
+  repeated Tx txs = 1;
+  optional string next_page_token = 2;
+}
 
 message StatusRequest {}
 message StatusReply {

--- a/txpool/txpool.proto
+++ b/txpool/txpool.proto
@@ -48,7 +48,7 @@ message SearchRequest {
     optional bytes from = 1;
   }
   Tx.Type type = 1;
-  optional Filter filter = 2;
+  Filter filter = 2;
 }
 message SearchReply { repeated Tx txs = 1; }
 

--- a/txpool/txpool.proto
+++ b/txpool/txpool.proto
@@ -45,10 +45,10 @@ message AllReply { repeated Tx txs = 1; }
 
 message SearchRequest {
   message Filter {
-    optional bytes from = 1;
+    optional Tx.Type type = 1;
+    optional bytes from = 2;
   }
-  Tx.Type type = 1;
-  Filter filter = 2;
+  Filter filter = 1;
 }
 message SearchReply { repeated Tx txs = 1; }
 

--- a/txpool/txpool.proto
+++ b/txpool/txpool.proto
@@ -71,7 +71,7 @@ service Txpool {
   rpc Transactions(TransactionsRequest) returns (TransactionsReply);
   // returns all transactions from tx pool
   rpc All(AllRequest) returns (AllReply);
-  // returns pending transactions from tx pool
+  // returns transactions from tx pool for criteria (type / filter)
   rpc Search(SearchRequest) returns (SearchReply);
   // subscribe to new transactions add event
   rpc OnAdd(OnAddRequest) returns (stream OnAddReply);


### PR DESCRIPTION
https://github.com/ledgerwatch/erigon/issues/2917

It will break some of the erigon's code in `ethdb/privateapi` since I moved `Tx` message out of `AllReply` to reuse it for `PendingReply`. Fixing it is an easy one.