### PR TITLE
RPC/Sentry: Peers method

### DIFF
--- a/p2psentry/sentry.proto
+++ b/p2psentry/sentry.proto
@@ -123,6 +123,10 @@ message MessagesRequest {
   repeated MessageId ids = 1;
 }
 
+message PeersReply {
+  repeated types.PeerInfo peers = 1;
+}
+
 message PeerCountRequest {}
 
 message PeerCountReply {uint64 count = 1;}
@@ -159,6 +163,7 @@ service Sentry {
   // It is possible to subscribe to the same set if ids more than once.
   rpc Messages(MessagesRequest) returns (stream InboundMessage);
 
+  rpc Peers(google.protobuf.Empty) returns (PeersReply);
   rpc PeerCount(PeerCountRequest) returns (PeerCountReply);
   // Subscribe to notifications about connected or lost peers.
   rpc PeerEvents(PeerEventsRequest) returns (stream PeerEvent);

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -47,11 +47,16 @@ service ETHBACKEND {
   // it doesn't provide consistency
   // Request fields are optional - it's ok to request block only by hash or only by number
   rpc Block(BlockRequest) returns (BlockReply);
+
   // High-level method - can find block number by txn hash
   // it doesn't provide consistency
   rpc TxnLookup(TxnLookupRequest) returns (TxnLookupReply);
-  // NodeInfo collects and returns NodeInfo from all running celery instances.
-  rpc NodeInfo(NodesInfoRequest) returns(NodesInfoReply);
+
+  // NodeInfo collects and returns NodeInfo from all running sentry instances.
+  rpc NodeInfo(NodesInfoRequest) returns (NodesInfoReply);
+
+  // Peers collects and returns peers information from all running sentry instances.
+  rpc Peers(google.protobuf.Empty) returns (PeersReply);
 }
 
 enum Event {
@@ -178,4 +183,8 @@ message NodesInfoRequest {
 
 message NodesInfoReply {
   repeated types.NodeInfoReply nodesInfo = 1;
+}
+
+message PeersReply {
+  repeated types.PeerInfo peers = 1;
 }

--- a/types/types.proto
+++ b/types/types.proto
@@ -89,3 +89,16 @@ message NodeInfoReply {
   string listenerAddr = 6;
   bytes protocols = 7;
 }
+
+message PeerInfo {
+  string id = 1;
+  string name = 2;
+  string enode = 3;
+  string enr = 4;
+  repeated string caps = 5;
+  string connLocalAddr = 6;
+  string connRemoteAddr = 7;
+  bool connIsInbound = 8;
+  bool connIsTrusted = 9;
+  bool connIsStatic = 10;
+}


### PR DESCRIPTION
Add a method to return information about all connected peers.
This is needed to implement admin_peers RPC call.