### PR TITLE
Switch from eth/66 to eth/67

### DIFF
--- a/_docs/README.md
+++ b/_docs/README.md
@@ -82,7 +82,7 @@ In Erigon, there are with two interfaces:
 
 ## 2. Sentry
 
-Sentry is the component, connecting the node to the p2p network of the blockchain. In case of Erigon and Ethereum, it implements [`eth/65`, `eth/66`, etc](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#change-log) protocols via [devp2p](https://github.com/ethereum/devp2p).
+Sentry is the component, connecting the node to the p2p network of the blockchain. In case of Erigon and Ethereum, it implements [`eth/67`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md) protocol via [devp2p](https://github.com/ethereum/devp2p).
 
 Sentry accepts connections from [Core] and [Transaction Pool] components.
 

--- a/p2psentry/sentry.proto
+++ b/p2psentry/sentry.proto
@@ -12,23 +12,23 @@ enum MessageId {
   // Version 67 removed the GetNodeData and NodeData messages.
 
   // eth/64 (or earlier) announcement messages (no request-id)
-  STATUS_64 = 0;
-  NEW_BLOCK_HASHES_64 = 1;
-  TRANSACTIONS_64 = 2;
-  NEW_BLOCK_64 = 3;
+  STATUS = 0;
+  NEW_BLOCK_HASHES = 1;
+  TRANSACTIONS = 2;
+  NEW_BLOCK = 3;
 
   // eth/65 announcement messages (no request-id)
-  NEW_POOLED_TRANSACTION_HASHES_65 = 4;
+  NEW_POOLED_TRANSACTION_HASHES = 4;
 
   // eth/66 messages with request-id
-  GET_BLOCK_HEADERS_66 = 5;
-  BLOCK_HEADERS_66 = 6;
-  GET_BLOCK_BODIES_66 = 7;
-  BLOCK_BODIES_66 = 8;
-  GET_POOLED_TRANSACTIONS_66 = 9;
-  POOLED_TRANSACTIONS_66 = 10;
-  GET_RECEIPTS_66 = 11;
-  RECEIPTS_66 = 12;
+  GET_BLOCK_HEADERS = 5;
+  BLOCK_HEADERS = 6;
+  GET_BLOCK_BODIES = 7;
+  BLOCK_BODIES = 8;
+  GET_POOLED_TRANSACTIONS = 9;
+  POOLED_TRANSACTIONS = 10;
+  GET_RECEIPTS = 11;
+  RECEIPTS = 12;
 }
 
 message OutboundMessageData {

--- a/p2psentry/sentry.proto
+++ b/p2psentry/sentry.proto
@@ -8,53 +8,27 @@ package sentry;
 option go_package = "./sentry;sentry";
 
 enum MessageId {
-  // ======= eth 65 protocol ===========
+  // ======= eth/67 protocol ===========
+  // Version 67 removed the GetNodeData and NodeData messages.
 
-  STATUS_65 = 0;
-  GET_BLOCK_HEADERS_65 = 1;
-  BLOCK_HEADERS_65 = 2;
-  BLOCK_HASHES_65 = 3;
-  GET_BLOCK_BODIES_65 = 4;
-  BLOCK_BODIES_65 = 5;
-  GET_NODE_DATA_65 = 6;
-  NODE_DATA_65 = 7;
-  GET_RECEIPTS_65 = 8;
-  RECEIPTS_65 = 9;
-  NEW_BLOCK_HASHES_65 = 10;
-  NEW_BLOCK_65 = 11;
-  TRANSACTIONS_65 = 12;
-  NEW_POOLED_TRANSACTION_HASHES_65 = 13;
-  GET_POOLED_TRANSACTIONS_65 = 14;
-  POOLED_TRANSACTIONS_65 = 15;
+  // eth/64 (or earlier) announcement messages (no request-id)
+  STATUS_64 = 0;
+  NEW_BLOCK_HASHES_64 = 1;
+  TRANSACTIONS_64 = 2;
+  NEW_BLOCK_64 = 3;
 
+  // eth/65 announcement messages (no request-id)
+  NEW_POOLED_TRANSACTION_HASHES_65 = 4;
 
-  // ======= eth 66 protocol ===========
-
-  // eth64 announcement messages (no id)
-  STATUS_66 = 17;
-  NEW_BLOCK_HASHES_66 = 18;
-  NEW_BLOCK_66 = 19;
-  TRANSACTIONS_66 = 20;
-
-  // eth65 announcement messages (no id)
-  NEW_POOLED_TRANSACTION_HASHES_66 = 21;
-
-  // eth66 messages with request-id
-  GET_BLOCK_HEADERS_66 = 22;
-  GET_BLOCK_BODIES_66 = 23;
-  GET_NODE_DATA_66 = 24;
-  GET_RECEIPTS_66 = 25;
-  GET_POOLED_TRANSACTIONS_66 = 26;
-  BLOCK_HEADERS_66 = 27;
-  BLOCK_BODIES_66 = 28;
-  NODE_DATA_66 = 29;
-  RECEIPTS_66 = 30;
-  POOLED_TRANSACTIONS_66 = 31;
-
-
-
-  // ======= eth 67 protocol ===========
-  // ...
+  // eth/66 messages with request-id
+  GET_BLOCK_HEADERS_66 = 5;
+  BLOCK_HEADERS_66 = 6;
+  GET_BLOCK_BODIES_66 = 7;
+  BLOCK_BODIES_66 = 8;
+  GET_POOLED_TRANSACTIONS_66 = 9;
+  POOLED_TRANSACTIONS_66 = 10;
+  GET_RECEIPTS_66 = 11;
+  RECEIPTS_66 = 12;
 }
 
 message OutboundMessageData {
@@ -111,8 +85,7 @@ message StatusData {
 }
 
 enum Protocol {
-  ETH65 = 0;
-  ETH66 = 1;
+  ETH67 = 0;
 }
 
 message SetStatusReply {}

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -32,7 +32,7 @@ service ETHBACKEND {
   // Version returns the service version number
   rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 
-  // ProtocolVersion returns the Ethereum protocol version number (e.g. 66 for ETH66).
+  // ProtocolVersion returns the Ethereum protocol version number (e.g. 67 for ETH67).
   rpc ProtocolVersion(ProtocolVersionRequest) returns (ProtocolVersionReply);
 
   // ClientVersion returns the Ethereum client version string using node name convention (e.g. TurboGeth/v2021.03.2-alpha/Linux).


### PR DESCRIPTION
Switch from [eth/66](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#eth66-eip-2481-april-2021) to  [eth/67](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#eth67-eip-4938-march-2022).

eth/67 removes `GetNodeData`/`NodeData` messages, which Erigon cannot serve, so with the move to eth/67 we become compliant.

See also [EIP-2481](https://eips.ethereum.org/EIPS/eip-2481) and https://github.com/ethereum/go-ethereum/pull/24093.