### PR TITLE
Add eth/67

### DIFF
--- a/p2psentry/sentry.proto
+++ b/p2psentry/sentry.proto
@@ -54,7 +54,7 @@ enum MessageId {
 
 
   // ======= eth 67 protocol ===========
-  // ...
+  // Version 67 removed the GetNodeData and NodeData messages.
 }
 
 message OutboundMessageData {
@@ -113,6 +113,7 @@ message StatusData {
 enum Protocol {
   ETH65 = 0;
   ETH66 = 1;
+  ETH67 = 2;
 }
 
 message SetStatusReply {}


### PR DESCRIPTION
This adds [eth/67](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#eth67-eip-4938-march-2022) in a backwards-compatible manner unlike PR #113.