### PR TITLE
add PendingBlock to EthBackend

### DIFF
--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -57,6 +57,8 @@ service ETHBACKEND {
 
   // Peers collects and returns peers information from all running sentry instances.
   rpc Peers(google.protobuf.Empty) returns (PeersReply);
+
+  rpc PendingBlock(google.protobuf.Empty) returns (PendingBlockReply);
 }
 
 enum Event {
@@ -186,4 +188,8 @@ message NodesInfoReply {
 
 message PeersReply {
   repeated types.PeerInfo peers = 1;
+}
+
+message PendingBlockReply {
+  bytes blockRlp = 1;
 }


### PR DESCRIPTION
This method is needed to wire the most recent of `EthBackendServer.builders.block` as the pending block into `eth_getBlockByNumber`
https://github.com/ledgerwatch/erigon/issues/2771