### PR TITLE
Use *protobuf_src* to find the latest *protoc*

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,12 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - run: sudo apt-get install -y libext2fs-dev
-
-      - uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ prost = "0.11"
 tonic = "0.8"
 
 [build-dependencies]
+protobuf-src = "1.1.0"
 prost-build = "0.11"
 tonic-build = "0.8"

--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,8 @@ fn make_protos(protos: &[&str]) {
 }
 
 fn main() {
+    std::env::set_var("PROTOC", protobuf_src::protoc());
+
     let mut protos = vec!["types/types.proto"];
 
     if cfg!(feature = "sentry") {


### PR DESCRIPTION
When building Akula, I experienced a few problems with protoc.

Following the instructions in https://docs.rs/prost-build/latest/prost_build/

I have added a line to build.rs
