### PR TITLE
Unify Engine API V1 & V2 methods

### DIFF
--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -19,22 +19,13 @@ service ETHBACKEND {
   // See https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md
 
   // Validate and possibly execute the payload.
-  rpc EngineNewPayloadV1(types.ExecutionPayload) returns (EnginePayloadStatus);
-
-  // Validate and possibly execute the payload.
-  rpc EngineNewPayloadV2(types.ExecutionPayloadV2) returns (EnginePayloadStatus);
+  rpc EngineNewPayload(types.ExecutionPayload) returns (EnginePayloadStatus);
 
   // Update fork choice
-  rpc EngineForkChoiceUpdatedV1(EngineForkChoiceUpdatedRequest) returns (EngineForkChoiceUpdatedReply);
-
-  // Update fork choice
-  rpc EngineForkChoiceUpdatedV2(EngineForkChoiceUpdatedRequestV2) returns (EngineForkChoiceUpdatedReply);
+  rpc EngineForkChoiceUpdated(EngineForkChoiceUpdatedRequest) returns (EngineForkChoiceUpdatedResponse);
 
   // Fetch Execution Payload using its ID.
-  rpc EngineGetPayloadV1(EngineGetPayloadRequest) returns (types.ExecutionPayload);
-
-  // Fetch Execution Payload using its ID.
-  rpc EngineGetPayloadV2(EngineGetPayloadRequest) returns (types.ExecutionPayloadV2);
+  rpc EngineGetPayload(EngineGetPayloadRequest) returns (EngineGetPayloadResponse);
 
   rpc EngineGetPayloadBodiesByHashV1(EngineGetPayloadBodiesByHashV1Request) returns (EngineGetPayloadBodiesV1Response);
 
@@ -117,9 +108,11 @@ message EnginePayloadStatus {
 }
 
 message EnginePayloadAttributes {
-  uint64 timestamp = 1;
-  types.H256 prevRandao = 2;
-  types.H160 suggestedFeeRecipient = 3;
+  uint32 version = 1; // Engine API version
+  uint64 timestamp = 2;
+  types.H256 prevRandao = 3;
+  types.H160 suggestedFeeRecipient = 4;
+  repeated types.Withdrawal withdrawals = 5;
 }
 
 message EngineForkChoiceState {
@@ -133,19 +126,14 @@ message EngineForkChoiceUpdatedRequest {
   EnginePayloadAttributes payloadAttributes = 2;
 }
 
-message EnginePayloadAttributesV2 {
-  EnginePayloadAttributes attributes = 1;
-  repeated types.Withdrawal withdrawals = 2;
-}
-
-message EngineForkChoiceUpdatedRequestV2 {
-  EngineForkChoiceState forkchoiceState = 1;
-  EnginePayloadAttributesV2 payloadAttributes = 2;
-}
-
-message EngineForkChoiceUpdatedReply {
+message EngineForkChoiceUpdatedResponse {
   EnginePayloadStatus payloadStatus = 1;
   uint64 payloadId = 2;
+}
+
+message EngineGetPayloadResponse {
+  types.ExecutionPayload executionPayload = 1;
+  types.H256 blockValue = 2;
 }
 
 message ProtocolVersionRequest {}

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -108,7 +108,7 @@ message EnginePayloadStatus {
 }
 
 message EnginePayloadAttributes {
-  uint32 version = 1; // Engine API version
+  uint32 version = 1; // v1 - no withdrawals, v2 - with withdrawals
   uint64 timestamp = 2;
   types.H256 prevRandao = 3;
   types.H160 suggestedFeeRecipient = 4;

--- a/types/types.proto
+++ b/types/types.proto
@@ -59,20 +59,22 @@ message VersionReply {
 // Engine API types
 // See https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md
 message ExecutionPayload {
-  H256 parentHash = 1;
-  H160 coinbase = 2;
-  H256 stateRoot = 3;
-  H256 receiptRoot = 4;
-  H2048 logsBloom = 5;
-  H256 prevRandao = 6;
-  uint64 blockNumber = 7;
-  uint64 gasLimit = 8;
-  uint64 gasUsed = 9;
-  uint64 timestamp = 10;
-  bytes extraData = 11;
-  H256 baseFeePerGas = 12;
-  H256 blockHash = 13;
-  repeated bytes transactions = 14;
+  uint32 version = 1; // Engine API version
+  H256 parentHash = 2;
+  H160 coinbase = 3;
+  H256 stateRoot = 4;
+  H256 receiptRoot = 5;
+  H2048 logsBloom = 6;
+  H256 prevRandao = 7;
+  uint64 blockNumber = 8;
+  uint64 gasLimit = 9;
+  uint64 gasUsed = 10;
+  uint64 timestamp = 11;
+  bytes extraData = 12;
+  H256 baseFeePerGas = 13;
+  H256 blockHash = 14;
+  repeated bytes transactions = 15;
+  repeated Withdrawal withdrawals = 16;
 }
 
 message Withdrawal {
@@ -80,11 +82,6 @@ message Withdrawal {
   uint64 validatorIndex = 2;
   H160 address = 3;
   uint64 amount = 4;
-}
-
-message ExecutionPayloadV2 {
-  ExecutionPayload payload = 1;
-  repeated Withdrawal withdrawals = 2;
 }
 // End of Engine API types
 // ------------------------------------------------------------------------

--- a/types/types.proto
+++ b/types/types.proto
@@ -59,7 +59,7 @@ message VersionReply {
 // Engine API types
 // See https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md
 message ExecutionPayload {
-  uint32 version = 1; // Engine API version
+  uint32 version = 1; // v1 - no withdrawals, v2 - with withdrawals
   H256 parentHash = 2;
   H160 coinbase = 3;
   H256 stateRoot = 4;


### PR DESCRIPTION
N.B. [Protobuf](https://developers.google.com/protocol-buffers/docs/proto3) does not distinguish between `nil` & empty value for `repeated` fields, thus the introduction of `version` to indicate the presence/absence of withdrawals.