### PR TITLE
Header mix_digest -> prev_randao

### DIFF
--- a/execution/execution.proto
+++ b/execution/execution.proto
@@ -36,7 +36,7 @@ message Header {
   types.H256 state_root = 3;
   types.H256 receipt_root = 4;
   types.H2048 logs_bloom = 5;
-  types.H256 mix_digest = 6;
+  types.H256 prev_randao = 6;
   uint64 block_number = 7;
   uint64 gas_limit = 8;
   uint64 gas_used = 9;


### PR DESCRIPTION
[EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) recommends renaming `mixHash` to `prevRandao`.