### PR TITLE
Add addPeer RPC

### DIFF
--- a/p2psentry/sentry.proto
+++ b/p2psentry/sentry.proto
@@ -93,6 +93,10 @@ message PeerMinBlockRequest {
   uint64 min_block = 2;
 }
 
+message AddPeerRequest {
+  string url = 1;
+}
+
 message InboundMessage {
   MessageId id = 1;
   bytes data = 2;
@@ -163,6 +167,10 @@ message PeerEvent {
   PeerEventId event_id = 2;
 }
 
+message AddPeerReply {
+  bool success = 1;
+}
+
 service Sentry {
   // SetStatus - force new ETH client state of sentry - network_id, max_block, etc...
   rpc SetStatus(StatusData) returns (SetStatusReply);
@@ -189,6 +197,8 @@ service Sentry {
   rpc PeerById(PeerByIdRequest) returns (PeerByIdReply);
   // Subscribe to notifications about connected or lost peers.
   rpc PeerEvents(PeerEventsRequest) returns (stream PeerEvent);
+
+  rpc AddPeer(AddPeerRequest) returns (AddPeerReply);
 
   // NodeInfo returns a collection of metadata known about the host.
   rpc NodeInfo(google.protobuf.Empty) returns(types.NodeInfoReply);

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -63,6 +63,8 @@ service ETHBACKEND {
   // Peers collects and returns peers information from all running sentry instances.
   rpc Peers(google.protobuf.Empty) returns (PeersReply);
 
+  rpc AddPeer(AddPeerRequest) returns (AddPeerReply);
+
   rpc PendingBlock(google.protobuf.Empty) returns (PendingBlockReply);
 }
 
@@ -195,12 +197,20 @@ message NodesInfoRequest {
   uint32 limit = 1;
 }
 
+message AddPeerRequest {
+  string url = 1;
+}
+
 message NodesInfoReply {
   repeated types.NodeInfoReply nodes_info = 1;
 }
 
 message PeersReply {
   repeated types.PeerInfo peers = 1;
+}
+
+message AddPeerReply {
+  bool success = 1;
 }
 
 message PendingBlockReply {


### PR DESCRIPTION
This PR mirrors https://github.com/testinprod-io/erigon-interfaces/pull/6.

Protobuf implementation for `admin_addPeer` method.
RPC Spec: Refer to https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-admin.