### PR TITLE
Improve fork choice update

### DIFF
--- a/execution/execution.proto
+++ b/execution/execution.proto
@@ -110,4 +110,5 @@ service Execution {
     rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
     rpc IsCanonicalHash(types.H256) returns(IsCanonicalResponse);
     rpc GetHeaderHashNumber(types.H256) returns(GetHeaderHashNumberResponse);
+    rpc GetLastForkChoice(EmptyMessage) returns(ForkChoice);
 }

--- a/execution/execution.proto
+++ b/execution/execution.proto
@@ -13,8 +13,15 @@ enum ValidationStatus {
     MissingSegment = 3; // Chain segments are missing.
 }
 
+enum ForkChoiceStatus {
+    Accepted = 0;      // Fork choice accepted.
+    InvalidHead = 1;
+    InvalidFinalizedBlock = 2;
+    InvalidSafeBlock = 3;
+}
+
 message ForkChoiceReceipt {
-    bool success = 1; // Forkchoice is either successful or unsuccessful.
+    ForkChoiceStatus status = 1;
     types.H256 latest_valid_hash = 2; // Return latest valid hash in case of halt of execution.
 }
 

--- a/execution/execution.proto
+++ b/execution/execution.proto
@@ -89,6 +89,12 @@ message InsertBodiesRequest {
     repeated BlockBody bodies = 1;
 }
 
+message ForkChoice {
+    types.H256 head_block_hash = 1;
+    optional types.H256 finalized_block_hash = 2;
+    optional types.H256 safe_block_hash = 3;
+}
+
 message EmptyMessage {}
 
 service Execution {
@@ -97,7 +103,7 @@ service Execution {
     rpc InsertBodies(InsertBodiesRequest) returns(EmptyMessage);
     // Chain Validation and ForkChoice.
     rpc ValidateChain(types.H256) returns(ValidationReceipt);
-    rpc UpdateForkChoice(types.H256) returns(ForkChoiceReceipt);
+    rpc UpdateForkChoice(ForkChoice) returns(ForkChoiceReceipt);
     rpc AssembleBlock(EmptyMessage) returns(types.ExecutionPayload); // Builds on top of current head.
     // Chain Getters.
     rpc GetHeader(GetSegmentRequest) returns(GetHeaderResponse);


### PR DESCRIPTION
Calling _sync_ the part that uses this interface and _exec_ the part that implements it, this PR allows a richer exchange of information between sync and exec that could make the current PoS implementation easier and could be useful by implementing other consensus mechanisms:

1) in the result of a `ForkChoiceUpdate` it is useful to disambiguate between different reasons of failure because the sync must send to external consensus client different responses:
 - `error code -38002` if finalized block or safe block are invalid
 - `{payloadStatus: {status: INVALID ... }}` if the head is invalid

2) `finalized_block_hash` might be used by exec to accept or not a future fork that is below this block (although this can happen, but with slashing)

3) retrieving the last `FCU` from sync can be useful after a node restart although we don't use it now