### PR TITLE
Retrieve the block progress and the last N headers

### DIFF
--- a/execution/execution.proto
+++ b/execution/execution.proto
@@ -89,6 +89,18 @@ message InsertBodiesRequest {
     repeated BlockBody bodies = 1;
 }
 
+message BlockProgress {
+  uint64 max_height = 1;
+}
+
+message LastNHeadersRequest {
+  uint64 count = 1;
+}
+
+message LastNHeaders {
+  repeated Header headers = 1;
+}
+
 message EmptyMessage {}
 
 service Execution {
@@ -104,4 +116,6 @@ service Execution {
     rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
     rpc IsCanonicalHash(types.H256) returns(IsCanonicalResponse);
     rpc GetHeaderHashNumber(types.H256) returns(GetHeaderHashNumberResponse);
+    rpc GetBlockProgress(EmptyMessage) returns(BlockProgress);
+    rpc GetLastHeaders(LastNHeadersRequest) returns(LastNHeaders);
 }


### PR DESCRIPTION
Calling _sync_ the part that uses this interface and _exec_ the part that implements it, this PR adds two getters:

- the last N headers
- the block progress

Actually, they are used in the sync of Silkworm after a node restart. Infact after a restart the sync must:

- know the last downloaded block to avoid downloading already downloaded blocks
- recalculate the last head (in the PoW consensus) - note that the block progress can be ahead of the canonical head and the _sync_ to calculate the current assumed head needs the last N headers
