### PR TITLE
rpc SetSubscribeExpiry

### DIFF
--- a/p2psentinel/sentinel.proto
+++ b/p2psentinel/sentinel.proto
@@ -81,7 +81,7 @@ message IdentityResponse {
 
 message RequestSubscribeExpiry {
     string topic = 1;
-    uint64 expiry_unix_sec = 2;
+    uint64 expiry_unix_secs = 2;
 }
 
 service Sentinel {

--- a/p2psentinel/sentinel.proto
+++ b/p2psentinel/sentinel.proto
@@ -79,7 +79,13 @@ message IdentityResponse {
     Metadata metadata = 5;
 }
 
+message RequestSubscribeExpiry {
+    string topic = 1;
+    uint64 expiry_unix_sec = 2;
+}
+
 service Sentinel {
+    rpc SetSubscribeExpiry(RequestSubscribeExpiry) returns(EmptyMessage);
     rpc SubscribeGossip(SubscriptionData) returns (stream GossipData);
     rpc SendRequest(RequestData) returns (ResponseData);
     rpc SetStatus(Status) returns(EmptyMessage); // Set status for peer filtering.


### PR DESCRIPTION
Sentinel now allow us to setup expiry time, so define a rpc to control it.
related pr: https://github.com/ledgerwatch/erigon/pull/9734