### PR TITLE
Better support for BlobAndProofV2

### DIFF
--- a/txpool/txpool.proto
+++ b/txpool/txpool.proto
@@ -84,9 +84,13 @@ message GetBlobsRequest{
   repeated types.H256 blob_hashes = 1;
 }
 
-message GetBlobsReply{
-  repeated bytes blobs = 1;
+message BlobAndProof {
+  bytes blob = 1;
   repeated bytes proofs = 2;
+}
+
+message GetBlobsReply {
+  repeated BlobAndProof blobs_with_proofs = 1;
 }
 
 service Txpool {


### PR DESCRIPTION
More direct mapping of proofs to blobs allowing to avoid index trickery in the `engine_getblobs` implementation (see [engine_getblobsv2](https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#engine_getblobsv2)).