### PR TITLE
p2psentry: add eth/70 protocol and message IDs (EIP-7975)

### DIFF
--- a/p2psentry/sentry.proto
+++ b/p2psentry/sentry.proto
@@ -67,6 +67,10 @@ enum MessageId {
   STATUS_69 = 37;
   GET_RECEIPTS_69 = 38;
   BLOCK_RANGE_UPDATE_69 = 39;
+
+  // ======= eth 70 protocol ===========
+  GET_RECEIPTS_70 = 40;
+  RECEIPTS_70 = 41;
 }
 
 message OutboundMessageData {
@@ -151,6 +155,7 @@ enum Protocol {
   ETH67 = 2;
   ETH68 = 3;
   ETH69 = 4;
+  ETH70 = 6;
   WIT0 = 5;
 }
 


### PR DESCRIPTION
## Summary

- Add `GET_RECEIPTS_70 = 40` and `RECEIPTS_70 = 41` to `MessageId` enum
- Add `ETH70 = 6` to `Protocol` enum

Companion to https://github.com/erigontech/erigon/pull/19755

🤖 Generated with [Claude Code](https://claude.com/claude-code)